### PR TITLE
Don't use alpha versions in version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { file = "LICENSE" } 
 classifiers = []
 dependencies = [
-    "tomli; python_version < '3.11.0a7'",
+    "tomli; python_version < '3.11'",
     "flake8"
 ]
 


### PR DESCRIPTION
It could potentially break package management tools such as `pdm`.