### PR TITLE
Modify the AST of _find_config_file

### DIFF
--- a/pflake8/__init__.py
+++ b/pflake8/__init__.py
@@ -1,6 +1,6 @@
 """ pyproject-flake8 (`pflake8`), a monkey patching wrapper to connect flake8 with pyproject.toml configuration """  # noqa
 
-__version__ = '4.0.1a1'
+__version__ = '5.0.0'
 
 import ast
 import configparser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { file = "LICENSE" }
 classifiers = []
 dependencies = [
     "tomli; python_version < '3.11'",
-    "flake8 >= 4.0.1"
+    "flake8 == 5.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Approach to change `_find_config_file` to support `pyproject.toml` via modifying its AST.

See https://github.com/csachs/pyproject-flake8/pull/14 .