### PR TITLE
Add reference to flake8-pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Two other projects aim to address the same problem:
 
 Both seem to try to do a lot more than just getting `pyproject.toml` support. `pyproject-flake8` tries to stay minimal while solving its task. 
 
+[`flake8-pyproject`](https://github.com/john-hen/Flake8-pyproject) adds only `pyproject.toml` support, and does this as a Flake8 plugin, allowing
+the original `flake8` command to work (rather than using `pflake8`).
+
 ## Caveat
 
 This script monkey-patches flake8 and the configparser library of Python, therefore loading it as a module may have unforeseen consequences.


### PR DESCRIPTION
[`flake8-pyproject`](https://github.com/john-hen/Flake8-pyproject) solves this issue as a Flake8 plugin, which has some advantages, chiefly that the original `flake8` command can be used, which helps with integration with some editors. It also does not monkey patch, which might be more sustainable long term?

See also:

- https://github.com/john-hen/Flake8-pyproject/issues/2