### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     name: Python ${{ matrix.python-version }} testing
     steps:
       - uses: actions/checkout@v3

--- a/pflake8/__init__.py
+++ b/pflake8/__init__.py
@@ -52,13 +52,20 @@ class DivertingConfigParser(ConfigParserTomlMixin, configparser.ConfigParser):
     pass
 
 
-class DivertingSafeConfigParser(ConfigParserTomlMixin, configparser.SafeConfigParser):
-    pass
+try:
+
+    class DivertingSafeConfigParser(
+        ConfigParserTomlMixin, configparser.SafeConfigParser
+    ):
+        pass
+
+    configparser.SafeConfigParser = DivertingSafeConfigParser
+except AttributeError:
+    pass  # does not exist on Python 3.12 (https://github.com/python/cpython/issues/89336#issuecomment-1094366625)
 
 
 configparser.RawConfigParser = DivertingRawConfigParser
 configparser.ConfigParser = DivertingConfigParser
-configparser.SafeConfigParser = DivertingSafeConfigParser
 
 
 class FixFilenames(ast.NodeTransformer):


### PR DESCRIPTION
Python 3.12 configparser removed SafeConfigParser. 
https://github.com/python/cpython/issues/89336#issuecomment-1094366625

leading to this issue

```
Traceback (most recent call last):
  File "/home/user/.cache/pypoetry/virtualenvs/chapter-marker-bSlZRqHo-py3.12/bin/pflake8", line 5, in <module>
    from pflake8.__main__ import main
  File "/home/user/.cache/pypoetry/virtualenvs/chapter-marker-bSlZRqHo-py3.12/lib/python3.12/site-packages/pflake8/__init__.py", line 54, in <module>
    class DivertingSafeConfigParser(ConfigParserTomlMixin, configparser.SafeConfigParser):
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'
```