### PR TITLE
Add a support of `--append-config` 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,4 @@ jobs:
       - name: Install
         run: python -m pip install .
       - name: Test
-        working-directory: .github/workflows/test
-        run: pflake8
+        run: python -m unittest discover -v -s test

--- a/.github/workflows/test/pyproject.toml
+++ b/.github/workflows/test/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.flake8]
-max-line-length = 88

--- a/.github/workflows/test/testfile.py
+++ b/.github/workflows/test/testfile.py
@@ -1,1 +1,0 @@
-too_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long = 1

--- a/pflake8/__init__.py
+++ b/pflake8/__init__.py
@@ -32,8 +32,11 @@ class ConfigParserTomlMixin:
             )
 
             for section, config in section_to_copy.items():
-                self.add_section(section)
-                self._sections[section] = self._dict(config)
+                try:
+                    self.add_section(section)
+                except (configparser.DuplicateSectionError):
+                    pass
+                self._sections.setdefault(section, self._dict()).update(self._dict(config))
         else:
             super(ConfigParserTomlMixin, self)._read(fp, filename)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ multi_line_output = 3
 max-line-length = 88
 extend-ignore = ["E203"]
 max-complexity = 10
-exclude = "venv"
+exclude = ["venv", "test/data/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ name = "pflake8"
 
 [tool.black]
 skip-string-normalization = 1
+force-exclude = [
+    "test/data/dummy.py",
+]
 
 [tool.isort]
 profile = "black"

--- a/test/data/dummy.py
+++ b/test/data/dummy.py
@@ -1,0 +1,5 @@
+d = {"a" : 1}  # E203
+
+
+def a_long_name_function_definition(x="this is a test for", y="--max-line-length setting."):  # E501
+    pass

--- a/test/data/pyproject.toml
+++ b/test/data/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.flake8]
+extend-ignore = ["E203"]

--- a/test/data/setup.cfg
+++ b/test/data/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/test/data/setup_custom.cfg
+++ b/test/data/setup_custom.cfg
@@ -1,0 +1,2 @@
+[flake8]
+extend-ignore = E203

--- a/test/test_append_config.py
+++ b/test/test_append_config.py
@@ -4,7 +4,6 @@ import pflake8
 
 
 class TestAppendConfig(unittest.TestCase):
-
     def test_append_config_toml(self):
         sys.argv = [
             "pflake8",
@@ -12,7 +11,7 @@ class TestAppendConfig(unittest.TestCase):
             "./test/data/setup.cfg",
             "--append-config",
             "./test/data/pyproject.toml",
-            "./test/data/dummy.py"
+            "./test/data/dummy.py",
         ]
 
         pflake8.main()  # OK if this raises no exception.
@@ -24,7 +23,7 @@ class TestAppendConfig(unittest.TestCase):
             "./test/data/setup.cfg",
             "--append-config",
             "./test/data/setup_custom.cfg",
-            "./test/data/dummy.py"
+            "./test/data/dummy.py",
         ]
 
         pflake8.main()  # OK if this raises no exception.

--- a/test/test_append_config.py
+++ b/test/test_append_config.py
@@ -1,0 +1,34 @@
+import sys
+import unittest
+import pflake8
+
+
+class TestAppendConfig(unittest.TestCase):
+
+    def test_append_config_toml(self):
+        sys.argv = [
+            "pflake8",
+            "--config",
+            "./test/data/setup.cfg",
+            "--append-config",
+            "./test/data/pyproject.toml",
+            "./test/data/dummy.py"
+        ]
+
+        pflake8.main()  # OK if this raises no exception.
+
+    def test_append_config_normal(self):
+        sys.argv = [
+            "pflake8",
+            "--config",
+            "./test/data/setup.cfg",
+            "--append-config",
+            "./test/data/setup_custom.cfg",
+            "./test/data/dummy.py"
+        ]
+
+        pflake8.main()  # OK if this raises no exception.
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The flake8 supports `--append-config` [option](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-append-config) that overwrites a default config that is automatically loaded (or specified in --config).
But the current pflake8 raises error when pyproject.toml set in --append-config:

```
# pflake8 --append-config pyproject.toml
Traceback (most recent call last):
  File "/opt/conda/bin/pflake8", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
  File "/opt/conda/lib/python3.11/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
  File "/opt/conda/lib/python3.11/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
  File "/opt/conda/lib/python3.11/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
                                 ^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/flake8/options/parse_args.py", line 29, in parse_args
    cfg, cfg_dir = config.load_config(
                   ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/flake8/options/config.py", line 90, in load_config
    if not cfg.read(filename, encoding="UTF-8"):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/configparser.py", line 713, in read
    self._read(fp, filename)
  File "/opt/conda/lib/python3.11/site-packages/pflake8/__init__.py", line 35, in _read
    self.add_section(section)
  File "/opt/conda/lib/python3.11/configparser.py", line 674, in add_section
    raise DuplicateSectionError(section)
configparser.DuplicateSectionError: Section 'flake8' already exists

```

This PR allows to use pyproject.toml in --append-config.
I also added simple test cases.

