### PR TITLE
Remove deprecated RawConfigParser (deprecated in python 3.12)

### DIFF
--- a/pflake8/__init__.py
+++ b/pflake8/__init__.py
@@ -52,13 +52,8 @@ class DivertingConfigParser(ConfigParserTomlMixin, configparser.ConfigParser):
     pass
 
 
-class DivertingSafeConfigParser(ConfigParserTomlMixin, configparser.SafeConfigParser):
-    pass
-
-
 configparser.RawConfigParser = DivertingRawConfigParser
 configparser.ConfigParser = DivertingConfigParser
-configparser.SafeConfigParser = DivertingSafeConfigParser
 
 
 class FixFilenames(ast.NodeTransformer):


### PR DESCRIPTION
Hi, 

I believe python 3.12 has removed `SafeConfigParser`.

This issue has been raised across multiple projects: here are a few examples: 
* https://github.com/lra/mackup/issues/1948
* https://github.com/pydata/pandas-datareader/issues/969

I don't find any other references of `SafeConfigParser` in the repo, so I assume it'll be safe to remove it. Please let me know if that's not the case. 

Here is the error when running pflake8 with python3.12
```
$ pflake8
Traceback (most recent call last):
  File "/home/ubuntu/flask-multipass-saml-groups/.tox/lint/bin/pflake8", line 5, in <module>
    from pflake8.__main__ import main
  File "/home/ubuntu/flask-multipass-saml-groups/.tox/lint/lib/python3.12/site-packages/pflake8/__init__.py", line 54, in <module>
    class DivertingSafeConfigParser(ConfigParserTomlMixin, configparser.SafeConfigParser):
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
```